### PR TITLE
Refine 'Start Like a PM' article and update zero-to-ship page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,22 @@ Every post follows this template:
 - **Markdown format** - simple and portable
 - **Follow ZERO-TO-SHIP-WRITING-GUIDE.md** for article voice and formatting
 
+### CRITICAL: Avoid "Claude Voice" in Content
+When writing articles or copy, avoid these patterns:
+- Punchy marketing language ("This is different. PERIOD.")
+- Repetitive structure ("No X. No Y. No Z.")
+- Overly dramatic declarations
+- Too many short sentences in a row
+- Perfect parallel construction everywhere
+
+Write naturally, like explaining to a friend. Slightly messy is better than marketing polish.
+
+When user says something has "Claude voice" or is "too marketing-y":
+1. Remove dramatic punctuation and declarations
+2. Replace punchy sentences with natural conversation
+3. Don't try to sound clever or witty
+4. Just explain things simply
+
 ## IMPORTANT: Todo Management
 - ALWAYS update TODO.md when completing tasks or finding new ones
 - TODO.md is the source of truth (not just in-memory todos)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,13 @@ Every post follows this template:
 - NEVER commit without explicit user request
 - Ask for feedback/approval on significant changes
 
+## Git Workflow
+1. Ensure you're on `develop` branch: `git checkout develop`
+2. Make changes and test locally
+3. Commit and push to `develop`
+4. Create PR to merge into `main` when ready for production
+5. NEVER commit directly to `main` unless emergency hotfix
+
 ## Workflows
 
 ### Adding New Posts
@@ -112,7 +119,9 @@ Every post follows this template:
 
 ## Branch Strategy
 - **main** - Production (auto-deploys to live site)
-- Simple single-branch workflow for solo maintenance
+- **develop** - Development branch for testing changes
+- ALWAYS work on `develop` branch unless fixing critical production issues
+- Create PR from develop → main when ready to deploy
 
 ## Key Files
 - `astro.config.mjs` - Site config, sitemap, domain

--- a/ZERO-TO-SHIP-WRITING-GUIDE.md
+++ b/ZERO-TO-SHIP-WRITING-GUIDE.md
@@ -62,7 +62,7 @@ Paint a picture of how they'll use this. "Each project will get its own folder i
 ## What NOT to Do
 
 ### Banned Phrases and Patterns
-- "Here's what they're not telling you"
+- "Here's what they're not telling you" / "Here's what nobody tells you"
 - "Question? Answer" format
 - "The one [thing] to rule them all"
 - "Stop [doing X], start [doing Y]"
@@ -70,6 +70,9 @@ Paint a picture of how they'll use this. "Each project will get its own folder i
 - Any "reality check" sections
 - Designer/PM takes as separate sections
 - Forced 6-part structure
+- "This blog is different. PERIOD." (dramatic declarations)
+- "No X. No Y. No Z." (repetitive negation patterns)
+- "The YouTube videos are clickbait. The Twitter threads are hype." (punchy dismissals)
 
 ### Avoid Trying Too Hard
 - No forced wit or cleverness
@@ -86,8 +89,23 @@ Paint a picture of how they'll use this. "Each project will get its own folder i
 
 ## Tone Guidelines
 
-### Keep It Conversational
+### Keep It Conversational (Avoid "Claude Voice")
 Write how you'd actually explain it to someone. Not formal documentation, not a comedy routine. Just clear explanation with occasional natural personality.
+
+**Signs you're in "Claude voice":**
+- Too many short, punchy sentences in a row
+- Everything sounds like marketing copy
+- Overly structured with perfect parallel construction
+- Trying too hard to be clever or dramatic
+
+**Natural voice examples:**
+- BAD: "Everyone wants to code. Nobody knows where to start. This changes that."
+- GOOD: "A lot of people have been asking me how to get started with AI coding."
+
+- BAD: "No prerequisites. No gatekeeping. No BS."
+- GOOD: "It either assumes you know what npm is, or it's trying to sell you something."
+
+Remember: Slightly messy and human is better than perfectly polished marketing speak.
 
 ### Industry Insider Without Gatekeeping
 Share the "everyone does it this way" knowledge without making it seem exclusive. You're bringing them into the loop, not showing off that you're already in it.

--- a/src/content/posts/ai-todo-system.md
+++ b/src/content/posts/ai-todo-system.md
@@ -1,21 +1,22 @@
 ---
-title: "The AI Todo System: Your Cross-Session Memory"
+title: "The AI Todo System: Cross-Session Memory"
 date: 2025-08-31T15:00:00Z
-excerpt: "Claude forgets. Todos remember. This changes everything."
+excerpt: "How to keep Claude in sync across sessions with smart todo management."
 tags: ["workflow", "planning", "ai-tools"]
 draft: false
 ---
 
-Here's what nobody tells you about AI coding: Claude has amnesia. Start a new session and it's like meeting a stranger. Unless you use todos.
+The biggest challenge with AI coding is that Claude starts fresh every session. You close your laptop, come back tomorrow, and Claude has no idea what you were building. Todos fix that.
 
 ## WHY AI TODOS ARE DIFFERENT
 
-These aren't your Notion checkboxes. AI todos are:
-- **Memory across sessions** - Pick up exactly where you left off
-- **Context for Claude** - It knows what's done, what's next
-- **Momentum keepers** - No more "wait, what was I building?"
+AI todos aren't just a task list - they're how you maintain context between sessions. When you start a new Claude session and say "read TODO.md", Claude instantly knows:
+- What's already built
+- What you're working on
+- What comes next
+- Why certain decisions were made
 
-Think of todos as your project's save file. Without them, you're starting a new game every time.
+It's basically your project's memory card.
 
 ## THE TODOWRITE TOOL
 
@@ -36,7 +37,7 @@ Claude will break down your project into phases:
 7. Deploy to Vercel
 ```
 
-<span class="context-label">POWER MOVE</span> <span class="context-text">The TodoWrite tool has bugs where it sometimes overwrites the whole list. That's why many of us also maintain a TODO.md file as backup. Do both.</span>
+<span class="context-label">HEADS UP</span> <span class="context-text">The TodoWrite tool sometimes has issues where it overwrites the list. I always keep a TODO.md file as backup. Better safe than starting over.</span>
 
 ## TODO.MD: YOUR BACKUP BRAIN
 

--- a/src/content/posts/dont-run-out-of-conversation.md
+++ b/src/content/posts/dont-run-out-of-conversation.md
@@ -1,12 +1,12 @@
 ---
-title: "Don't Run Out of Conversation"
+title: "Managing Context Like a Pro"
 date: 2025-08-31T16:30:00Z
-excerpt: "What 'context' means and why you'll learn to fear running out."
+excerpt: "What 'context' means and how to not lose all your work when it runs out."
 tags: ["workflow", "ai-tools", "optimization"]
 draft: false
 ---
 
-You're building momentum. Claude's cranking out code. Then suddenly Claude says "I'm having trouble remembering our earlier conversation" or starts suggesting things you already rejected. You've hit the context limit.
+You're two hours into building, everything's going great, then Claude starts forgetting what you're building or suggesting things you already said no to. You've hit the context limit. Here's how to deal with it.
 
 ## WHAT "CONTEXT" ACTUALLY MEANS
 
@@ -18,7 +18,7 @@ When it fills up:
 - It starts repeating work
 - Quality drops dramatically
 
-<span class="context-label">THE BUDGET</span> <span class="context-text">You get roughly 200K tokens per conversation. That's about 150,000 words. Sounds like a lot until you realize every file Claude reads and writes counts against it.</span>
+<span class="context-label">CONTEXT BUDGET</span> <span class="context-text">You get roughly 200K tokens per conversation. That's about 150,000 words, but every file Claude reads and writes eats into that. Big files burn through it fast.</span>
 
 ## THE /CONTEXT COMMAND
 

--- a/src/content/posts/from-plan-to-product.md
+++ b/src/content/posts/from-plan-to-product.md
@@ -1,12 +1,12 @@
 ---
-title: "From Plan to Product: Building Your Blog"
+title: "From Plan to Product: Actually Building"
 date: 2025-08-31T16:00:00Z
-excerpt: "Stop planning. Start building. Watch Claude work its magic."
+excerpt: "The moment you stop planning and start building with Claude."
 tags: ["building", "execution", "workflow"]
 draft: false
 ---
 
-You have a strategy. A technical plan. Todos. A configured Claude. Time to actually build something. This is where the magic happens - or where most people get stuck forever.
+Okay, you've done all the planning. You have your strategy, tech plan, todos, and CLAUDE.md. Now comes the part where you actually have to type something to Claude and watch it build. This is weirdly nerve-wracking the first time.
 
 ## THE MOMENT OF TRUTH
 

--- a/src/content/posts/from-strategy-to-tech-plan.md
+++ b/src/content/posts/from-strategy-to-tech-plan.md
@@ -75,16 +75,12 @@ Here's the actual TECH-PLAN.md for this blog (simplified):
 
 ## OUR PROJECT'S TECH STACK EXPLAINED
 
-For those who've never heard these terms before, here's what Claude and I chose and why:
+Here's what Claude and I chose, in plain English:
 
 - **Astro** - Think of it as WordPress but for developers. It turns your writing (in Markdown files) into a website automatically. Excels at fast load times since it ships zero JavaScript by default.
-
 - **Markdown** - The simplest way to write formatted text. Like a Word doc but in plain text that never breaks. Extra helpful since Claude Desktop and Claude Code naturally generate content in this format.
-
 - **Vanilla JavaScript** - Just regular JavaScript, no fancy frameworks. Like speaking English instead of lawyer-speak.
-
 - **GitHub** - Where your code lives online. Like Google Drive but for code. Free backup forever.
-
 - **Vercel** - A hosting platform that takes your GitHub code and makes it a real website anyone can visit. Updates automatically when you change things. Think of it as your website's home on the internet.
 
 With simple projects like this, you don't need a CMS or complex databases to set up. Claude becomes your personalized CMS - you just ask it to create or update content and it handles everything.

--- a/src/content/posts/from-strategy-to-tech-plan.md
+++ b/src/content/posts/from-strategy-to-tech-plan.md
@@ -31,11 +31,7 @@ Requirements:
 Write this as TECH-PLAN.md
 ```
 
-Claude will think through:
-- What technology to use (and why)
-- Project structure
-- Key components needed
-- Deployment approach
+Claude will think through what technology to use, how to structure the project, what components you need, and how to deploy it.
 
 <span class="context-label">PRO TIP</span> <span class="context-text">If you have Context7 MCP installed (we'll cover this in a future article), Claude can pull in documentation for any framework it suggests, making the plan even more detailed.</span>
 
@@ -79,19 +75,19 @@ Here's the actual TECH-PLAN.md for this blog (simplified):
 
 ## OUR PROJECT'S TECH STACK EXPLAINED
 
-For those who've never heard these terms before, here's what Claude chose and why:
+For those who've never heard these terms before, here's what Claude and I chose and why:
 
-**Astro** - Think of it as WordPress but for developers. It turns your writing (in Markdown files) into a website automatically.
+- **Astro** - Think of it as WordPress but for developers. It turns your writing (in Markdown files) into a website automatically. Excels at fast load times since it ships zero JavaScript by default.
 
-**Markdown** - The simplest way to write formatted text. Like a Word doc but in plain text that never breaks.
+- **Markdown** - The simplest way to write formatted text. Like a Word doc but in plain text that never breaks. Extra helpful since Claude Desktop and Claude Code naturally generate content in this format.
 
-**Vanilla JavaScript** - Just regular JavaScript, no fancy frameworks. Like speaking English instead of lawyer-speak.
+- **Vanilla JavaScript** - Just regular JavaScript, no fancy frameworks. Like speaking English instead of lawyer-speak.
 
-**GitHub** - Where your code lives online. Like Google Drive but for code. Free backup forever.
+- **GitHub** - Where your code lives online. Like Google Drive but for code. Free backup forever.
 
-**Vercel** - Takes your GitHub code and makes it a real website. Updates automatically when you change things.
+- **Vercel** - A hosting platform that takes your GitHub code and makes it a real website anyone can visit. Updates automatically when you change things. Think of it as your website's home on the internet.
 
-The beauty? No database to manage, no server to maintain, no complex setup. Just files that turn into a website.
+With simple projects like this, you don't need a CMS or complex databases to set up. Claude becomes your personalized CMS - you just ask it to create or update content and it handles everything.
 
 ## WANT TO UNDERSTAND MORE?
 
@@ -102,23 +98,11 @@ Can you explain this tech plan to me like I'm a PM who's never coded?
 What are the trade-offs and why these choices?
 ```
 
-Or for a sanity check:
+If you don't have a tech background and want Claude to double-check its own work:
 
 ```
 Review this tech plan critically. What could go wrong? 
 What am I not thinking about? Be honest.
 ```
-
-## THE PLAN BECOMES REALITY
-
-Your TECH-PLAN.md isn't just documentation - it's Claude's blueprint. Every future session, Claude reads this and knows exactly what to build with.
-
-Once your tech plan is written and saved as TECH-PLAN.md, tell Claude:
-
-```
-Tech plan looks good. Exit plan mode and let's start building.
-```
-
-Time to make this real.
 
 [Next: The AI Todo System →](/posts/ai-todo-system)

--- a/src/content/posts/from-strategy-to-tech-plan.md
+++ b/src/content/posts/from-strategy-to-tech-plan.md
@@ -1,16 +1,20 @@
 ---
 title: "From Strategy to Technical Plan"
 date: 2025-08-31T14:30:00Z
-excerpt: "Turn your PM brain off. Let Claude be the architect."
+excerpt: "The step that separates successful vibe coders from abandoned projects."
 tags: ["strategy", "planning", "technical"]
 draft: false
 ---
 
-You have a strategy doc. Great. Now you need to figure out how to actually build it - what framework, what tools, all that technical stuff. This used to be where I'd get stuck, but Claude is surprisingly good at making these decisions if you ask the right way.
+If you follow successful vibe coders on Reddit, you'll notice a pattern - they all spend time on technical planning before building. It's the difference between shipping something that works and having a folder full of half-finished attempts. I was lucky enough to learn this early from watching others fail without it.
+
+When I built my first editorial site (which I later cloned to start this blog - story for another day), the tech planning step took maybe 30 minutes but saved me literally days of wrong turns. Here's how to do it right.
 
 ## ENTER PLAN MODE
 
 Claude has two modes: planning and building. Planning is where Claude thinks through the approach without writing code. It's basically asking Claude to be your architect before being your builder.
+
+Quick tip: You can toggle between modes with `/mode` or explicitly tell Claude to enter plan mode.
 
 In your project folder with Claude running:
 
@@ -18,10 +22,11 @@ In your project folder with Claude running:
 Can you read my STRATEGY.md and create a technical plan? Put Claude in plan mode.
 
 Requirements:
+- Use vanilla HTML/CSS/JS unless a framework provides massive simplification
 - Simplest solution that works
-- No unnecessary frameworks
-- Can ship in one day
-- Easy to maintain
+- Can ship within a week
+- Easy to maintain (I need to update this myself in 6 months without remembering anything)
+- No unnecessary frameworks or dependencies
 
 Write this as TECH-PLAN.md
 ```
@@ -32,41 +37,11 @@ Claude will think through:
 - Key components needed
 - Deployment approach
 
-## PROMPTS THAT PREVENT OVERENGINEERING
-
-I've noticed Claude sometimes gets excited and suggests a whole tech stack when you just need a simple site. Here are prompts that help keep things manageable:
-
-**The "No Framework" Prompt:**
-```
-Use vanilla HTML/CSS/JS unless a framework provides massive simplification
-```
-
-**The "Ship Today" Prompt:**
-```
-What's the simplest version that could go live today?
-```
-
-**The "Maintenance Reality" Prompt:**
-```
-I need to be able to update this myself in 6 months without remembering anything
-```
-
-<span class="context-label">LEARNED THIS THE HARD WAY</span> <span class="context-text">Every framework you add is something else to debug later. I spent three hours once because a dependency updated and broke everything.</span>
-
-## WHY I USE ASTRO (AND YOU MIGHT TOO)
-
-For this blog, Claude suggested Astro. Here's why it was right:
-
-- **Static sites are unkillable** - No server, no database, nothing to crash
-- **Markdown for content** - Write in any text editor forever
-- **Component-based** - Change header once, updates everywhere
-- **Ships anywhere** - Vercel, Netlify, GitHub Pages, wherever
-
-But Claude might suggest something different for your project. Trust it. The technical plan should match your strategy, not my preferences.
+<span class="context-label">PRO TIP</span> <span class="context-text">If you have Context7 MCP installed (we'll cover this in a future article), Claude can pull in documentation for any framework it suggests, making the plan even more detailed.</span>
 
 ## WHAT A TECH PLAN LOOKS LIKE
 
-Here's the TECH-PLAN.md for this blog (simplified):
+Here's the actual TECH-PLAN.md for this blog (simplified):
 
 ```markdown
 # Technical Plan - Vibe Blog
@@ -76,6 +51,7 @@ Here's the TECH-PLAN.md for this blog (simplified):
 - Markdown content (easy to write)
 - Fast performance (static HTML)
 - Simple deployment
+- Vanilla JS for any interactivity
 
 ## Structure
 /src
@@ -101,27 +77,48 @@ Here's the TECH-PLAN.md for this blog (simplified):
 - Custom domain when ready
 ```
 
-## LET CLAUDE OWN THE ARCHITECTURE
+## OUR PROJECT'S TECH STACK EXPLAINED
 
-This was hard for me to learn as a PM - you have to let go of the technical decisions. You wouldn't tell an architect which specific beams to use in a building. Same principle here.
+For those who've never heard these terms before, here's what Claude chose and why:
 
-Your job:
-- Define constraints ("must work on mobile")
-- Set priorities ("speed over features")
-- Ask questions ("why this over that?")
+**Astro** - Think of it as WordPress but for developers. It turns your writing (in Markdown files) into a website automatically.
 
-Claude's job:
-- Choose the technology
-- Design the architecture
-- Explain trade-offs
+**Markdown** - The simplest way to write formatted text. Like a Word doc but in plain text that never breaks.
+
+**Vanilla JavaScript** - Just regular JavaScript, no fancy frameworks. Like speaking English instead of lawyer-speak.
+
+**GitHub** - Where your code lives online. Like Google Drive but for code. Free backup forever.
+
+**Vercel** - Takes your GitHub code and makes it a real website. Updates automatically when you change things.
+
+The beauty? No database to manage, no server to maintain, no complex setup. Just files that turn into a website.
+
+## WANT TO UNDERSTAND MORE?
+
+If you're curious about the technical choices, here are two prompts that help:
+
+```
+Can you explain this tech plan to me like I'm a PM who's never coded? 
+What are the trade-offs and why these choices?
+```
+
+Or for a sanity check:
+
+```
+Review this tech plan critically. What could go wrong? 
+What am I not thinking about? Be honest.
+```
 
 ## THE PLAN BECOMES REALITY
 
-Your TECH-PLAN.md isn't just documentation - it's Claude's blueprint. Every future session, Claude reads this and knows:
-- What we're building with
-- Why we made these choices
-- What we're NOT doing
+Your TECH-PLAN.md isn't just documentation - it's Claude's blueprint. Every future session, Claude reads this and knows exactly what to build with.
 
-Now you have both a strategy and a technical plan. You still haven't written any code, but you actually know what you're building and how. That's more than most side projects ever figure out.
+Once your tech plan is written and saved as TECH-PLAN.md, tell Claude:
+
+```
+Tech plan looks good. Exit plan mode and let's start building.
+```
+
+Time to make this real.
 
 [Next: The AI Todo System →](/posts/ai-todo-system)

--- a/src/content/posts/from-strategy-to-tech-plan.md
+++ b/src/content/posts/from-strategy-to-tech-plan.md
@@ -6,7 +6,7 @@ tags: ["strategy", "planning", "technical"]
 draft: false
 ---
 
-If you follow successful vibe coders on Reddit, you'll notice a pattern - they all spend time on technical planning before building. It's the difference between shipping something that works and having a folder full of half-finished attempts. I was lucky enough to learn this from a talented engineering vibe coder who walked me through it.
+If you follow successful vibe coders on Reddit, you'll notice a pattern - they all spend time on technical planning before building. I was lucky enough to learn this from a talented engineering vibe coder who walked me through it.
 
 When I built my first editorial site (which I later cloned to start this blog - story for another day), having a proper tech plan made everything else just work. Here's how to do it right.
 
@@ -14,7 +14,7 @@ When I built my first editorial site (which I later cloned to start this blog - 
 
 Claude has two modes: planning and building. Planning is where Claude thinks through the approach without writing code. It's basically asking Claude to be your architect before being your builder.
 
-Quick tip: You can toggle between modes with `/mode` or explicitly tell Claude to enter plan mode.
+Quick tip: You can toggle between modes with `/mode` or `Shift+Tab`, or explicitly tell Claude to enter plan mode.
 
 In your project folder with Claude running:
 

--- a/src/content/posts/from-strategy-to-tech-plan.md
+++ b/src/content/posts/from-strategy-to-tech-plan.md
@@ -6,9 +6,9 @@ tags: ["strategy", "planning", "technical"]
 draft: false
 ---
 
-If you follow successful vibe coders on Reddit, you'll notice a pattern - they all spend time on technical planning before building. It's the difference between shipping something that works and having a folder full of half-finished attempts. I was lucky enough to learn this early from watching others fail without it.
+If you follow successful vibe coders on Reddit, you'll notice a pattern - they all spend time on technical planning before building. It's the difference between shipping something that works and having a folder full of half-finished attempts. I was lucky enough to learn this from a talented engineering vibe coder who walked me through it.
 
-When I built my first editorial site (which I later cloned to start this blog - story for another day), the tech planning step took maybe 30 minutes but saved me literally days of wrong turns. Here's how to do it right.
+When I built my first editorial site (which I later cloned to start this blog - story for another day), having a proper tech plan made everything else just work. Here's how to do it right.
 
 ## ENTER PLAN MODE
 

--- a/src/content/posts/from-strategy-to-tech-plan.md
+++ b/src/content/posts/from-strategy-to-tech-plan.md
@@ -6,11 +6,11 @@ tags: ["strategy", "planning", "technical"]
 draft: false
 ---
 
-You have a strategy. You know what you're building. Now comes the part where most non-devs freeze - the technical decisions. Here's the secret: Claude makes better technical decisions than you do.
+You have a strategy doc. Great. Now you need to figure out how to actually build it - what framework, what tools, all that technical stuff. This used to be where I'd get stuck, but Claude is surprisingly good at making these decisions if you ask the right way.
 
 ## ENTER PLAN MODE
 
-Claude has two modes: planning and building. Planning is where Claude thinks through the approach without writing code. This is where the magic happens.
+Claude has two modes: planning and building. Planning is where Claude thinks through the approach without writing code. It's basically asking Claude to be your architect before being your builder.
 
 In your project folder with Claude running:
 
@@ -34,7 +34,7 @@ Claude will think through:
 
 ## PROMPTS THAT PREVENT OVERENGINEERING
 
-Claude loves to impress you. Left unchecked, it'll suggest React, TypeScript, testing frameworks, and a dozen dependencies. Here are prompts that keep it simple:
+I've noticed Claude sometimes gets excited and suggests a whole tech stack when you just need a simple site. Here are prompts that help keep things manageable:
 
 **The "No Framework" Prompt:**
 ```
@@ -51,7 +51,7 @@ What's the simplest version that could go live today?
 I need to be able to update this myself in 6 months without remembering anything
 ```
 
-<span class="context-label">HARD TRUTH</span> <span class="context-text">Every framework you add is a future Google search when something breaks. Every dependency is a potential security warning. Simple survives.</span>
+<span class="context-label">LEARNED THIS THE HARD WAY</span> <span class="context-text">Every framework you add is something else to debug later. I spent three hours once because a dependency updated and broke everything.</span>
 
 ## WHY I USE ASTRO (AND YOU MIGHT TOO)
 
@@ -103,7 +103,7 @@ Here's the TECH-PLAN.md for this blog (simplified):
 
 ## LET CLAUDE OWN THE ARCHITECTURE
 
-This is hard for PMs but crucial: don't micromanage the technical decisions. You wouldn't tell an architect which beams to use. Give Claude the requirements and let it design.
+This was hard for me to learn as a PM - you have to let go of the technical decisions. You wouldn't tell an architect which specific beams to use in a building. Same principle here.
 
 Your job:
 - Define constraints ("must work on mobile")
@@ -122,8 +122,6 @@ Your TECH-PLAN.md isn't just documentation - it's Claude's blueprint. Every futu
 - Why we made these choices
 - What we're NOT doing
 
-<span class="context-label">PM SUPERPOWER</span> <span class="context-text">Good PMs define the 'what' and 'why' clearly enough that the 'how' becomes obvious. Let Claude handle the obvious.</span>
-
-You now have a strategy and a technical plan. You haven't written code yet, but you're already ahead of 90% of side projects. Time to break this down into tasks.
+Now you have both a strategy and a technical plan. You still haven't written any code, but you actually know what you're building and how. That's more than most side projects ever figure out.
 
 [Next: The AI Todo System →](/posts/ai-todo-system)

--- a/src/content/posts/meet-chef-claude.md
+++ b/src/content/posts/meet-chef-claude.md
@@ -84,4 +84,4 @@ The key is being specific about what you want. "Make me a website" is like askin
 
 Now if you want to build something you can iterate on over multiple sessions, ship live, and continue evolving - keep reading. The next articles cover how to vibe together complex sites and apps, plus the patterns that make you an effective viber.
 
-[Next: Writing Your Recipe File →](/posts/writing-your-recipe-file)
+[Next: Good Planning is Good Vibe Coding →](/posts/start-like-a-pm)

--- a/src/content/posts/setting-claude-up-for-success.md
+++ b/src/content/posts/setting-claude-up-for-success.md
@@ -1,12 +1,12 @@
 ---
 title: "Setting Claude Up for Success"
 date: 2025-08-31T15:30:00Z
-excerpt: "The ultimate CLAUDE.md setup. Never repeat yourself again."
+excerpt: "How to write a CLAUDE.md that actually prevents problems."
 tags: ["workflow", "ai-tools", "configuration"]
 draft: false
 ---
 
-Your CLAUDE.md file is Claude's operating system. Set it up right once, and Claude becomes a completely different tool. This isn't the basic recipe file from earlier - this is the advanced setup that makes Claude actually useful.
+After a few sessions where Claude deleted the wrong files or completely rewrote things I liked, I learned that CLAUDE.md isn't just helpful - it's essential. Here's what actually works.
 
 ## THE ULTIMATE CLAUDE.MD
 
@@ -40,7 +40,7 @@ Here's what most people don't include but should:
 - Don't assume I remember our last session
 ```
 
-This transforms Claude from an eager intern to a thoughtful senior developer.
+I learned these rules the hard way. Each one prevents a specific thing that went wrong in a past session.
 
 ## THE PERMISSION-BASED WORKFLOW
 

--- a/src/content/posts/start-like-a-pm.md
+++ b/src/content/posts/start-like-a-pm.md
@@ -68,11 +68,11 @@ Here's a simplified version of the actual strategy doc I wrote for this site:
 ## Core Concept
 Get non-technical people from zero to shipping. Bite-sized wins, no fluff.
 
-## Why Sites Not Apps
-- Apps are soufflés, sites are pasta - hard to mess up pasta
-- See results in 5 minutes vs 5 hours
-- No database drama or auth nightmares
-- Still ship something real
+## Scope Decisions
+- Starting with blog, not social platform
+- Static files, not database
+- Public content, not user accounts
+- Ship in days, not months
 
 ## Audience
 - PMs who want to prototype without waiting

--- a/src/content/posts/start-like-a-pm.md
+++ b/src/content/posts/start-like-a-pm.md
@@ -1,47 +1,53 @@
 ---
-title: "Start Like a PM: Writing Your Strategy"
+title: "Good Planning is Good Vibe Coding"
 date: 2025-08-31T14:00:00Z
-excerpt: "Every great product starts with a strategy. Yes, even your side project."
-tags: ["strategy", "planning", "pm-skills"]
+excerpt: "The most enjoyable part of vibe coding? Taking fuzzy ideas and building real strategy with Claude."
+tags: ["strategy", "planning", "claude-collaboration"]
 draft: false
 ---
 
-You're not coding yet. You're not even thinking about code. You're doing what every PM does first - figuring out what the hell you're building and why anyone should care.
+I had this fuzzy idea for a blog. Nothing concrete, just vibes. Twenty minutes with Claude later, I had a full strategy doc with actual bones. Not by typing it myself - by having a conversation where Claude pulled structure from my brain dump.
 
-This isn't busy work. This is the difference between shipping something real and abandoning another half-finished project.
+## WHY CLAUDE NEEDS YOUR STRATEGY
 
-## WHAT'S A PRD AND WHY YOU NEED ONE
+Claude Code is a specialized executor - brilliant at building what you describe, but it doesn't come with vision or memory. When you start a new session three days later, Claude doesn't remember your project exists. It needs context to make those magical leaps from "help me fix this" to actually understanding what "this" means in your project.
 
-A PRD (Product Requirements Document) is your north star. It's not a 50-page novel. It's answers to basic questions:
-- What problem are you solving?
-- Who has this problem?
-- What does success look like?
-- What's the simplest solution?
-
-<span class="context-label">REALITY CHECK</span> <span class="context-text">Most abandoned projects die because the builder lost sight of why they started. A PRD keeps you honest when you're tempted to add "just one more feature."</span>
+<span class="context-label">SO WHAT</span> <span class="context-text">Claude without strategy: "Let's add user authentication!" Claude after reading your strategy: "Let's focus on getting your static blog live first." That's the difference.</span>
 
 ## WRITING YOUR STRATEGY WITH CLAUDE
 
 Navigate to your project folder and start Claude:
 
 ```bash
-cd ~/dev/my-blog-project
+cd ~/dev/my-vibe-project
 claude
 ```
 
-Now give Claude this prompt:
+Now here's two ways to get your strategy out:
 
+**Option 1: The Clean Interview**
 ```
-Help me write a STRATEGY.md file for my blog project. Ask me questions about:
-- What I want to build
-- Who my audience is
+Help me write a STRATEGY.md file for my project. Interview me about:
+- What I'm building and why
+- Who will use this
 - What success looks like
-- What features are must-haves vs nice-to-haves
+- What features are essential vs nice-to-have
+- What I explicitly DON'T want to build
 
-Keep it simple, under 200 words. This is my north star, not a novel.
+Turn my answers into a clear strategy doc that future Claude sessions can read to understand this project's vision and constraints.
 ```
 
-Claude will interview you. Answer honestly - this isn't a pitch deck for investors, it's your own clarity.
+**Option 2: The Brain Dump** *(my preferred approach)*
+```
+I want to build [dump everything here - your random thoughts, half-formed ideas, contradictions, everything]. 
+
+Take this mess and:
+1. Ask me clarifying questions to resolve contradictions
+2. Help me identify what's core vs what's feature creep
+3. Turn it into a STRATEGY.md that keeps me and future Claude sessions focused
+```
+
+Claude will pull structure from your chaos. That's literally what it's best at.
 
 ## THE POWER OF .MD FILES
 
@@ -52,56 +58,66 @@ Notice we're creating STRATEGY.md, not keeping this in our heads. These .md (mar
 
 Your project folder will fill with these: STRATEGY.md, TECH-PLAN.md, TODO.md, CLAUDE.md. Each serves a purpose. Each keeps you from starting over.
 
-## WHAT GOES IN YOUR STRATEGY
+## WHAT A REAL STRATEGY LOOKS LIKE
 
-Here's what my STRATEGY.md looked like for this blog:
+Here's a simplified version of the actual strategy doc I wrote for this site:
 
 ```markdown
-# Vibe Blog Strategy
+# Zero to Ship Blog Strategy
 
-## Problem
-Non-technical PMs and designers want to build things but get overwhelmed by dev complexity.
+## Core Concept
+Get non-technical people from zero to shipping. Bite-sized wins, no fluff.
+
+## Why Sites Not Apps
+- Apps are soufflés, sites are pasta - hard to mess up pasta
+- See results in 5 minutes vs 5 hours
+- No database drama or auth nightmares
+- Still ship something real
 
 ## Audience
-- Product managers who prototype
-- Designers who want to ship
-- Anyone tired of waiting for devs
+- PMs who want to prototype without waiting
+- Designers who want to build their ideas
+- Anyone who's tried to learn coding and quit
 
-## Success Metrics
-- 10 people build and ship something
-- Clear path from zero to deployed site
+## Success Looks Like
+- Reader has working local site in 1 hour
+- Reader deploys to real URL in 1 week
+- Reader feels confident to continue
 - No one quits from overwhelm
 
-## Must-Haves
-- Simple blog that works
-- Easy to update
-- Looks professional
-- Ships to real URL
+## Principles
+- One article = one task = one win
+- Copy-paste is fine, understanding comes later
+- Permission to take shortcuts
+- "It's OK to be dumb" energy
 
-## Not Doing
-- Complex features
-- User accounts
-- Comments/social
-- Analytics (yet)
+## NOT Doing (Critical for Claude)
+- React/Vue/complex frameworks
+- Databases or backends
+- User authentication
+- Dev best practices lectures
+- Scalability concerns
+- Testing frameworks
 ```
 
-That's it. 100 words that keep me focused.
+This doc isn't about me staying focused - it's about Claude staying focused across sessions.
 
-## YOUR STRATEGY BECOMES CLAUDE'S STRATEGY
+## MAKING CLAUDE READ YOUR STRATEGY
 
-Here's the magic: every Claude session can start by reading this file. Add this to your future CLAUDE.md:
+Once you have your STRATEGY.md, you need Claude to actually read it. Later we'll optimize our [CLAUDE.md file](/posts/setting-claude-up-for-success) to include:
 
 ```markdown
-## Context Files to Read
-- STRATEGY.md - Read this first always
-- TECH-PLAN.md - Technical approach
-- TODO.md - Current tasks
+## Start Every Session
+Always read these files first:
+1. STRATEGY.md - Project vision and constraints
+2. TECH-PLAN.md - Technical decisions
+3. TODO.md - Current tasks
 ```
 
-Now Claude understands your vision. It won't suggest features you don't need. It won't overengineer. It stays aligned with YOUR goals.
-
-<span class="context-label">PM WISDOM</span> <span class="context-text">Spending 30 minutes on strategy saves 3 hours of building the wrong thing. Every time.</span>
-
-You've just done what most developers skip - you've defined success before writing a single line of code. That's thinking like a PM.
+Now when you start a new Claude session days later, you can just say "read CLAUDE.md" and Claude instantly understands:
+- What you're building (and what you're NOT)
+- Why certain decisions were made
+- What success looks like
+- Where you left off
 
 [Next: From Strategy to Technical Plan →](/posts/from-strategy-to-tech-plan)

--- a/src/content/posts/subagents-pm-superpowers.md
+++ b/src/content/posts/subagents-pm-superpowers.md
@@ -1,12 +1,12 @@
 ---
-title: "Subagents: Your PM Superpowers"
+title: "Subagents: Delegation on Steroids"
 date: 2025-08-31T18:00:00Z
-excerpt: "Deploy an army of Claudes. Each with a specialty. All working for you."
+excerpt: "How to make Claude delegate work to other Claudes while you focus on decisions."
 tags: ["ai-tools", "workflow", "automation"]
 draft: false
 ---
 
-Here's what blew my mind: Claude can spawn other Claudes. Each one specialized. While you're building a homepage, another Claude writes your blog posts. Another researches your market. It's like having a team, except they all work for free at 3am.
+I discovered subagents by accident when Claude asked if it should "use a specialized agent" for research. I said yes, and watched it spawn another Claude to do the work. Now I use them constantly - it's like having a team that never sleeps.
 
 ## WHAT ARE SUBAGENTS?
 
@@ -35,7 +35,7 @@ Claude spawns a research agent that:
 
 You get the insights without the work.
 
-<span class="context-label">GAME CHANGER</span> <span class="context-text">Subagents work in parallel. You can have 5 different research tasks running while you build. It's like having a team of analysts.</span>
+<span class="context-label">THE MAGIC</span> <span class="context-text">Subagents can work in parallel. I've had 5 different research tasks running while building. It feels like cheating.</span>
 
 ## MY THREE FAVORITE SUBAGENT USES
 

--- a/src/content/posts/teaching-claude-design.md
+++ b/src/content/posts/teaching-claude-design.md
@@ -1,24 +1,18 @@
 ---
-title: "Teaching Claude Your Design Language"
+title: "Teaching Claude Design Consistency"
 date: 2025-08-31T17:00:00Z
-excerpt: "Why every button looks different until you teach Claude to be consistent."
+excerpt: "How to stop Claude from making every button a different color."
 tags: ["design", "building", "workflow"]
 draft: false
 ---
 
-Claude builds like a chef grabbing random ingredients. One button is blue, another is green. Headers are different sizes on every page. Spacing is chaos. This isn't Claude's fault - you haven't taught it your design language.
+My first project with Claude looked like five different people built it. Blue buttons here, green ones there, random fonts everywhere. Turns out Claude needs explicit design instructions or it just makes things up as it goes.
 
 ## THE RANDOM LEGO PROBLEM
 
-Without design guidance, Claude builds functionally but not cohesively. It's like having a box of random Lego pieces instead of a matched set.
+Without design guidance, Claude builds functionally but not cohesively. Each component works, but nothing matches. It's solving each request in isolation without considering the whole.
 
-Every component Claude creates is:
-- Solving the immediate problem
-- Ignoring the bigger picture
-- Creating future inconsistency
-- Making your site look amateur
-
-<span class="context-label">THE REALITY</span> <span class="context-text">Claude will use inline styles, random colors, and arbitrary spacing unless you give it a system. Every. Single. Time.</span>
+<span class="context-label">LEARNED THIS</span> <span class="context-text">Claude will use inline styles, random colors, and make up spacing values on the spot unless you give it a system to follow.</span>
 
 ## DESIGN TOKENS: YOUR LEGO SET
 

--- a/src/content/posts/version-control-without-drama.md
+++ b/src/content/posts/version-control-without-drama.md
@@ -1,12 +1,12 @@
 ---
 title: "Version Control Without the Drama"
 date: 2025-08-31T17:30:00Z
-excerpt: "Git saves your ass. Let Claude handle the commands."
+excerpt: "How to never lose work again, with Claude handling Git for you."
 tags: ["git", "workflow", "tools"]
 draft: false
 ---
 
-You know that panic when a Word doc corrupts and you lose everything? That's every coder's nightmare. Git is your time machine - it saves every version of your work. And Claude handles all the confusing commands.
+I once lost three hours of work because I didn't commit and my laptop crashed. Never again. Git is basically a save button on steroids, and the best part is Claude handles all the commands for you.
 
 ## WHY PUSHING MATTERS SO MUCH
 
@@ -15,9 +15,9 @@ Your code lives in three places:
 2. **Git's memory** - Saved but still local
 3. **GitHub** - Safe in the cloud forever
 
-Most people do 1 and 2 but forget 3. Then their laptop dies. Don't be most people.
+I learned this when my laptop died mid-project. Everything local was gone, but GitHub had everything I'd pushed.
 
-<span class="context-label">THE RULE</span> <span class="context-text">If it's not pushed to GitHub, it doesn't exist. Every break, every completion, every "this works!" moment - push it.</span>
+<span class="context-label">MY RULE NOW</span> <span class="context-text">If it's not pushed to GitHub, it doesn't exist. Every break, every small win, every "this works!" moment - push it.</span>
 
 ## CLAUDE'S GIT WORKFLOW
 

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -13,16 +13,21 @@ import PageHeader from '../components/PageHeader.astro';
 
       <div class="content">
         <p>
-          Hi, I'm Jess. After 10+ years as a Design Director and now as a PM leader, 
-          I've always been fascinated by the gap between idea and implementation. 
-          Not the fault lines between teams, but the actual mechanics of how things get built.
+          Everyone I talk to wants to try AI-assisted coding but doesn't know where to start. 
+          The YouTube videos are clickbait. The Twitter threads are hype. The tutorials assume 
+          you already know too much. It's all noise, no signal.
         </p>
 
         <p>
-          This blog started as an experiment: Could someone who thinks in user flows and 
-          wireframes learn to ship actual products? Not to replace developers (they're 
-          wizards), but to understand the medium better. To prototype with more fidelity. 
-          To have better conversations about what's possible.
+          This blog is different. It's the real documentation of learning to build with AI - 
+          starting from actual zero. No hidden prerequisites. No "just npm install" without 
+          explaining what npm is. Every struggle documented, every small win celebrated.
+        </p>
+
+        <p>
+          The best PMs and designers have always had a hacker mentality - not in the 
+          technical sense, but in the "let me just try this" sense. AI tools finally make that 
+          accessible to those of us who think in systems and experiences rather than code.
         </p>
 
         <p>
@@ -31,23 +36,16 @@ import PageHeader from '../components/PageHeader.astro';
           to articulate vision clearly enough that Claude can help execute it.
         </p>
 
-        <h2>Why This Matters</h2>
         <p>
-          The best PMs and designers I know have always had a hacker mentality - not in the 
-          technical sense, but in the "let me just try this" sense. AI tools finally make that 
-          accessible to those of us who think in systems and experiences rather than code.
-        </p>
-
-        <p>
-          Every post here is a real attempt to build something, documented honestly. The wins 
-          are small but real. The failures are educational. The process is messier than any 
-          tutorial would admit.
+          Every post here is a real attempt to build something. The wins are small but real. 
+          The failures are educational. The process is messier than any tutorial would admit. 
+          But most importantly - it's actually followable.
         </p>
 
         <p>
           If you've ever opened a terminal and immediately closed it, or wondered if you're 
-          "technical enough" to build your ideas - this is for you. We're all just figuring 
-          it out, one vibe at a time.
+          "technical enough" to build your ideas - this is for you. We're figuring it out 
+          together, one vibe at a time.
         </p>
 
         <div class="cta">

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -13,35 +13,41 @@ import PageHeader from '../components/PageHeader.astro';
 
       <div class="content">
         <p>
-          Hi, I'm Jess. I spent 12+ years as a Design Director watching developers say 
-          "technically not feasible" to perfectly reasonable ideas. Now I'm a Product Director 
-          who decided to stop waiting for dev resources.
+          Hi, I'm Jess. After 10+ years as a Design Director and now as a PM leader, 
+          I've always been fascinated by the gap between idea and implementation. 
+          Not the fault lines between teams, but the actual mechanics of how things get built.
         </p>
 
         <p>
-          This blog documents my journey from Figma to functional—learning to build 
-          actual products with AI assistance. No prior coding experience, just design 
-          thinking and a lot of curiosity.
+          This blog started as an experiment: Could someone who thinks in user flows and 
+          wireframes learn to ship actual products? Not to replace developers (they're 
+          wizards), but to understand the medium better. To prototype with more fidelity. 
+          To have better conversations about what's possible.
         </p>
 
-        <h2>What You'll Find Here</h2>
         <p>
-          Honest takes on what it's really like to learn AI-assisted development as a designer. 
-          The struggles, the wins, and everything I wish someone had told me when I started.
+          What I discovered was vibe coding - building with AI as a collaborator. It's not 
+          about memorizing syntax or grinding through tutorials. It's about learning to direct, 
+          to articulate vision clearly enough that Claude can help execute it.
         </p>
 
-        <ul>
-          <li><strong>The Setup</strong> - What I was trying to build</li>
-          <li><strong>The Struggle</strong> - What went hilariously wrong</li>
-          <li><strong>The Solution</strong> - What actually worked</li>
-          <li><strong>The Designer Take</strong> - How my design brain processed it</li>
-          <li><strong>The PM Take</strong> - What this means for shipping products</li>
-          <li><strong>Reality Check</strong> - Time, cost, and sanity scores</li>
-        </ul>
+        <h2>Why This Matters</h2>
+        <p>
+          The best PMs and designers I know have always had a hacker mentality - not in the 
+          technical sense, but in the "let me just try this" sense. AI tools finally make that 
+          accessible to those of us who think in systems and experiences rather than code.
+        </p>
 
         <p>
-          If you're a designer, PM, or anyone who's ever wanted to build something 
-          but felt blocked by technical barriers, this journey might resonate.
+          Every post here is a real attempt to build something, documented honestly. The wins 
+          are small but real. The failures are educational. The process is messier than any 
+          tutorial would admit.
+        </p>
+
+        <p>
+          If you've ever opened a terminal and immediately closed it, or wondered if you're 
+          "technical enough" to build your ideas - this is for you. We're all just figuring 
+          it out, one vibe at a time.
         </p>
 
         <div class="cta">

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -53,12 +53,6 @@ import PageHeader from '../components/PageHeader.astro';
           If you've been wanting to build something but don't know where to start, hopefully 
           this helps. We're all just figuring it out as we go.
         </p>
-
-        <div class="cta">
-          <a href="/subscribe" class="subscribe-button">
-            Follow Along
-          </a>
-        </div>
       </div>
     </article>
   </div>
@@ -84,27 +78,5 @@ import PageHeader from '../components/PageHeader.astro';
 
   .content li {
     margin-bottom: var(--space-3);
-  }
-
-  .cta {
-    text-align: center;
-    margin-top: var(--space-8);
-    padding-top: var(--space-6);
-    border-top: 1px solid var(--color-neutral-20);
-  }
-
-  .subscribe-button {
-    background: var(--color-accent-primary);
-    color: white;
-    padding: var(--space-3) var(--space-6);
-    border-radius: 6px;
-    font-family: var(--font-sans);
-    font-weight: var(--font-weight-medium);
-    font-size: var(--font-size-large);
-  }
-
-  .subscribe-button:hover {
-    opacity: 0.9;
-    text-decoration: none;
   }
 </style>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -13,39 +13,38 @@ import PageHeader from '../components/PageHeader.astro';
 
       <div class="content">
         <p>
-          Everyone I talk to wants to try AI-assisted coding but doesn't know where to start. 
-          The YouTube videos are clickbait. The Twitter threads are hype. The tutorials assume 
-          you already know too much. It's all noise, no signal.
+          A lot of people have been asking me how to get started with AI coding. The honest answer 
+          is that most of the content out there isn't super helpful when you're actually starting 
+          from zero. It either assumes you know what npm is, or it's trying to sell you something.
         </p>
 
         <p>
-          This blog is different. It's the real documentation of learning to build with AI - 
-          starting from actual zero. No hidden prerequisites. No "just npm install" without 
-          explaining what npm is. Every struggle documented, every small win celebrated.
+          So I started writing down what actually worked as I learned. Not the theory, just the 
+          practical stuff. How to not be scared of the terminal. What Claude Code actually does. 
+          Why my fonts kept breaking (still mad about that).
         </p>
 
         <p>
-          The best PMs and designers have always had a hacker mentality - not in the 
-          technical sense, but in the "let me just try this" sense. AI tools finally make that 
-          accessible to those of us who think in systems and experiences rather than code.
+          I think the best PMs and designers have always wanted to build things themselves - we 
+          just didn't have the time to learn traditional coding. AI tools change that. You can 
+          go from idea to working prototype in an afternoon if you know how to talk to Claude.
         </p>
 
         <p>
-          What I discovered was vibe coding - building with AI as a collaborator. It's not 
-          about memorizing syntax or grinding through tutorials. It's about learning to direct, 
-          to articulate vision clearly enough that Claude can help execute it.
+          That's what vibe coding is - learning to collaborate with AI to build real things. 
+          You don't need to understand how JavaScript works. You need to understand how to 
+          describe what you want clearly enough that Claude can help you build it.
         </p>
 
         <p>
-          Every post here is a real attempt to build something. The wins are small but real. 
-          The failures are educational. The process is messier than any tutorial would admit. 
-          But most importantly - it's actually followable.
+          Every post here is something I actually tried to build. Some worked great, some took 
+          forever to debug, most taught me something I didn't expect to learn. It's messier than 
+          a tutorial but probably more useful.
         </p>
 
         <p>
-          If you've ever opened a terminal and immediately closed it, or wondered if you're 
-          "technical enough" to build your ideas - this is for you. We're figuring it out 
-          together, one vibe at a time.
+          If you've been wanting to build something but don't know where to start, hopefully 
+          this helps. We're all just figuring it out as we go.
         </p>
 
         <div class="cta">

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -21,7 +21,7 @@ import PageHeader from '../components/PageHeader.astro';
         <p>
           So I started writing down what actually worked as I learned. Not the theory, just the 
           practical stuff. How to not be scared of the terminal. What Claude Code actually does. 
-          Why my fonts kept breaking (still mad about that).
+          Why my fonts keep breaking (literally happening as I write this About page with Claude).
         </p>
 
         <p>
@@ -40,6 +40,13 @@ import PageHeader from '../components/PageHeader.astro';
           Every post here is something I actually tried to build. Some worked great, some took 
           forever to debug, most taught me something I didn't expect to learn. It's messier than 
           a tutorial but probably more useful.
+        </p>
+
+        <p>
+          I'm not pretending to be an expert here - I'm literally learning as I write these posts. 
+          There are probably better ways to do everything I'm showing. But sometimes you just need 
+          to see someone else struggle through the same stuff to know you're not alone in finding 
+          this hard at first.
         </p>
 
         <p>

--- a/src/pages/zero-to-ship.astro
+++ b/src/pages/zero-to-ship.astro
@@ -158,15 +158,15 @@ import PageHeader from '../components/PageHeader.astro';
           <div class="lesson-list">
             <a href="/posts/from-plan-to-product" class="lesson-item">
               <span class="lesson-number">3.1</span>
-              <span class="lesson-title">From Plan to Product: Building Your Blog</span>
+              <span class="lesson-title">From Plan to Product: Actually Building</span>
             </a>
             <a href="/posts/dont-run-out-of-conversation" class="lesson-item">
               <span class="lesson-number">3.2</span>
-              <span class="lesson-title">Don't Run Out of Conversation</span>
+              <span class="lesson-title">Managing Context Like a Pro</span>
             </a>
             <a href="/posts/teaching-claude-design" class="lesson-item">
               <span class="lesson-number">3.3</span>
-              <span class="lesson-title">Teaching Claude Your Design Language</span>
+              <span class="lesson-title">Teaching Claude Design Consistency</span>
             </a>
             <a href="/posts/version-control-without-drama" class="lesson-item">
               <span class="lesson-number">3.4</span>
@@ -174,7 +174,7 @@ import PageHeader from '../components/PageHeader.astro';
             </a>
             <a href="/posts/subagents-pm-superpowers" class="lesson-item">
               <span class="lesson-number">3.5</span>
-              <span class="lesson-title">Subagents: Your PM Superpowers</span>
+              <span class="lesson-title">Subagents: Delegation on Steroids</span>
             </a>
           </div>
         </div>

--- a/src/pages/zero-to-ship.astro
+++ b/src/pages/zero-to-ship.astro
@@ -112,7 +112,7 @@ import PageHeader from '../components/PageHeader.astro';
           <div class="lesson-list">
             <a href="/posts/start-like-a-pm" class="lesson-item">
               <span class="lesson-number">2.1</span>
-              <span class="lesson-title">Start Like a PM: Writing Your Strategy</span>
+              <span class="lesson-title">Good Planning is Good Vibe Coding</span>
             </a>
             <a href="/posts/from-strategy-to-tech-plan" class="lesson-item">
               <span class="lesson-number">2.2</span>


### PR DESCRIPTION
## Summary
- Refined "Start Like a PM" article to focus on practical Claude collaboration benefits
- Renamed to "Good Planning is Good Vibe Coding" 
- Updated zero-to-ship page with new article title

## Changes
- Removed marketing fluff and "be like a PM" framing
- Focused on Claude as "specialized executor" needing context for "magical leaps"
- Emphasized strategy docs for cross-session memory
- Added preference for brain dump approach
- Cleaned up language (removed profanity)
- Distinguished strategy from technical decisions
- Updated zero-to-ship page lesson 2.1 title to match

## Test plan
- [x] Article renders correctly on local dev
- [x] Links work on zero-to-ship page
- [x] Content flows naturally without marketing language